### PR TITLE
adjustment in the translation pt-BR

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -7,7 +7,7 @@ pt-BR:
       is_at: 'deve ser em %{restriction}'
       before: 'deve ser antes de %{restriction}'
       on_or_before: 'deve ser antes ou em %{restriction}'
-      after: 'deve ser após de %{restriction}'
+      after: 'deve ser após %{restriction}'
       on_or_after: 'deve ser após ou em %{restriction}'
   validates_timeliness:
     error_value_formats:


### PR DESCRIPTION
It is only a small adjustment in the translation of the error message `` `after```

Examples bellow:

before:
Fim deve ser após de 07/07/2019
Fim deve ser após de 11:00:00
Fim deve ser após de 07/07/2019 11:00:00

after:
Fim deve ser após 07/07/2019
Fim deve ser após 11:00:00
Fim deve ser após 07/07/2019 11:00:00